### PR TITLE
Added support for facet.contains and facet.contains.ignoreCase

### DIFF
--- a/library/Solarium/Core/Client/Adapter/Curl.php
+++ b/library/Solarium/Core/Client/Adapter/Curl.php
@@ -156,7 +156,7 @@ class Curl extends Configurable implements AdapterInterface
         }
 
         if (!isset($options['headers']['Content-Type'])) {
-            $options['headers']['Content-Type'] = 'text/xml; charset=utf-8';
+            $options['headers']['Content-Type'] = '';
         }
 
         // Try endpoint authentication first, fallback to request for backwards compatibility

--- a/library/Solarium/QueryType/Select/Query/Component/Facet/Field.php
+++ b/library/Solarium/QueryType/Select/Query/Component/Facet/Field.php
@@ -152,6 +152,57 @@ class Field extends Facet
     }
 
     /**
+     * Limit the terms for faceting by a string they must contain
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @param  string $contains
+     * @return self   Provides fluent interface
+     */
+    public function setContains($contains)
+    {
+        return $this->setOption('contains', $contains);
+    }
+
+    /**
+     * Get the facet contains
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @return string
+     */
+    public function getContains()
+    {
+        return $this->getOption('contains');
+    }
+
+
+    /**
+     * Case sensitivity of matching string that facet terms must contain
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @param  boolean $containsIgnoreCase
+     * @return self    Provides fluent interface
+     */
+    public function setContainsIgnoreCase($containsIgnoreCase)
+    {
+        return $this->setOption('contains.ignoreCase', $containsIgnoreCase);
+    }
+
+    /**
+     * Get the case sensitivity of facet contains
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @return boolean
+     */
+    public function getContainsIgnoreCase()
+    {
+        return $this->getOption('contains.ignoreCase');
+    }
+
+    /**
      * Set the facet limit
      *
      * @param  int  $limit

--- a/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/Query/Component/FacetSet.php
@@ -203,6 +203,57 @@ class FacetSet extends Component
     }
 
     /**
+     * Limit the terms for faceting by a string they must contain
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @param  string $contains
+     * @return self   Provides fluent interface
+     */
+    public function setContains($contains)
+    {
+        return $this->setOption('contains', $contains);
+    }
+
+    /**
+     * Get the facet contains
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @return string
+     */
+    public function getContains()
+    {
+        return $this->getOption('contains');
+    }
+
+
+    /**
+     * Case sensitivity of matching string that facet terms must contain
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @param  boolean $containsIgnoreCase
+     * @return self    Provides fluent interface
+     */
+    public function setContainsIgnoreCase($containsIgnoreCase)
+    {
+        return $this->setOption('contains.ignoreCase', $containsIgnoreCase);
+    }
+
+    /**
+     * Get the case sensitivity of facet contains
+     *
+     * This is a global value for all facets in this facetset
+     *
+     * @return boolean
+     */
+    public function getContainsIgnoreCase()
+    {
+        return $this->getOption('contains.ignoreCase');
+    }
+
+    /**
      * Set the facet sort order
      *
      * Use one of the SORT_* constants as the value

--- a/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
+++ b/library/Solarium/QueryType/Select/RequestBuilder/Component/FacetSet.php
@@ -72,6 +72,8 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
             // global facet params
             $request->addParam('facet.sort', $component->getSort());
             $request->addParam('facet.prefix', $component->getPrefix());
+            $request->addParam('facet.contains', $component->getContains());
+            $request->addParam('facet.contains.ignoreCase', is_null($ignoreCase = $component->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
             $request->addParam('facet.missing', $component->getMissing());
             $request->addParam('facet.mincount', $component->getMinCount());
             $request->addParam('facet.limit', $component->getLimit());
@@ -124,6 +126,8 @@ class FacetSet extends RequestBuilder implements ComponentRequestBuilderInterfac
         $request->addParam("f.$field.facet.limit", $facet->getLimit());
         $request->addParam("f.$field.facet.sort", $facet->getSort());
         $request->addParam("f.$field.facet.prefix", $facet->getPrefix());
+        $request->addParam("f.$field.facet.contains", $facet->getContains());
+        $request->addParam("f.$field.facet.contains.ignoreCase", is_null($ignoreCase = $facet->getContainsIgnoreCase()) ? null : ($ignoreCase ? 'true' : 'false'));
         $request->addParam("f.$field.facet.offset", $facet->getOffset());
         $request->addParam("f.$field.facet.mincount", $facet->getMinCount());
         $request->addParam("f.$field.facet.missing", $facet->getMissing());


### PR DESCRIPTION
Sorl 5.1.0 added facet.contains and facet.contains.ignoreCase. I've added contains() and containsIgnoreCase() methods to facetsets and fields.

I had to remove the default Content-Type in the Curl adapter because the newer Solr doesn't accept text/xml anymore.
